### PR TITLE
Better compile times measurement

### DIFF
--- a/lib/purserl.ex
+++ b/lib/purserl.ex
@@ -254,8 +254,8 @@ defmodule DevHelpers.Purserl do
         cond do
           msg == "### launching compiler" ->
             IO.puts("Compiling ...")
-            {:noreply, %{ state | started_at: DateTime.utc_now() \
-                                , module_positions: %{}, erl_steps: %{}, compile_times: %{} }}
+            {:noreply, %{ state | started_at: DateTime.utc_now(),
+                                  module_positions: %{}, erl_steps: %{}, compile_times: %{} }}
 
           msg == "### read externs" ->
             {:noreply, state}
@@ -329,8 +329,8 @@ defmodule DevHelpers.Purserl do
                 [s_version, module] = v_and_mod |> String.split(" ", parts: 2)
 
                 module_info = {:maps.size(state.module_positions), step_in_brackets, s_version}
-                state = %{ state | module_positions: state.module_positions |> Map.put(module, module_info) \
-                                 , compile_times: state.compile_times |> Map.put(module, [ DateTime.utc_now() ])}
+                state = %{ state | module_positions: state.module_positions |> Map.put(module, module_info),
+                                   compile_times: state.compile_times |> Map.put(module, [ DateTime.utc_now() ])}
                 print_pretty_status(state, module)
 
                 # IO.inspect {:s_version, s_version, :module, module}
@@ -360,8 +360,8 @@ defmodule DevHelpers.Purserl do
 
   @impl true
   def handle_cast({:erl_step_complete, module}, state) do
-    state = %{ state | erl_steps: state.erl_steps |> Map.put(module, 1 + (state.erl_steps[module] || 0)) \
-                     , compile_times: state.compile_times |> Map.update(module, [ DateTime.utc_now() ], fn x -> x ++ [ DateTime.utc_now() ] end) }
+    state = %{ state | erl_steps: state.erl_steps |> Map.put(module, 1 + (state.erl_steps[module] || 0)),
+                       compile_times: state.compile_times |> Map.update(module, [ DateTime.utc_now() ], fn x -> x ++ [ DateTime.utc_now() ] end) }
     print_pretty_status(state, module)
     {:noreply, state}
   end

--- a/lib/purserl.ex
+++ b/lib/purserl.ex
@@ -104,7 +104,7 @@ defmodule Purserl do
 
   def durations() do
     compile_times()
-    |> Enum.map(fn {module, %{start: s, end: e}} -> {module, DateTime.diff(e, s, :milliseconds)} end)
+    |> Enum.map(fn {module, %{start: s, end: e}} -> {module, DateTime.diff(e, s, :millisecond)} end)
     |> Enum.into(%{})
   end
 

--- a/lib/purserl.ex
+++ b/lib/purserl.ex
@@ -41,7 +41,6 @@ defmodule Purserl do
       purs_args: config |> Keyword.get(:purs_args, ""),
       ctx_lines_above: config |> Keyword.get(:ctx_lines_above, 3) |> (fn x -> x + 1 end).(),
       ctx_lines_below: config |> Keyword.get(:ctx_lines_below, 3) |> (fn x -> x + 1 end).(),
-      single_line_compile_output: config |> Keyword.get(:single_line_compile_output, false),
       logfile:
         case config |> Keyword.get(:logfile_path, nil) do
           nil ->

--- a/lib/purserl.ex
+++ b/lib/purserl.ex
@@ -1,4 +1,4 @@
-defmodule DevHelpers.Purserl do
+defmodule Purserl do
   use GenServer
   alias IO.ANSI, as: Color
 
@@ -10,10 +10,8 @@ defmodule DevHelpers.Purserl do
 
   ###
 
-  @name :purserl_compiler
-
   def start(config) do
-    case GenServer.start(__MODULE__, config, name: @name) do
+    case GenServer.start(__MODULE__, config, name: __MODULE__) do
       {:ok, pid} -> {:ok, pid}
       {:error, {:already_started, pid}} -> {:ok, pid}
       res -> res
@@ -102,7 +100,7 @@ defmodule DevHelpers.Purserl do
   end
 
   def compile_times() do
-    GenServer.call(@name, :compile_times)
+    GenServer.call(__MODULE__, :compile_times)
   end
 
   def start_spago(state) do
@@ -262,12 +260,12 @@ defmodule DevHelpers.Purserl do
 
           msg |> String.starts_with?("### done compiler: 0") ->
             state = await_tasks(state)
-            GenServer.cast(@name, {:finish_up, :ok})
+            GenServer.cast(__MODULE__, {:finish_up, :ok})
             {:noreply, state}
 
           msg |> String.starts_with?("### done compiler: 1") ->
             state = await_tasks(state)
-            GenServer.cast(@name, {:finish_up, :err})
+            GenServer.cast(__MODULE__, {:finish_up, :err})
             {:noreply, state}
 
           msg |> String.starts_with?("### erl-same:") ->
@@ -275,7 +273,7 @@ defmodule DevHelpers.Purserl do
             "### erl-same:" <> path_to_changed_file = msg
             case path_to_changed_file |> String.split("/") do
               ["output", module | _ ] ->
-                GenServer.cast(@name, {:erl_step_complete, module})
+                GenServer.cast(__MODULE__, {:erl_step_complete, module})
               _ -> nil
             end
 
@@ -316,7 +314,7 @@ defmodule DevHelpers.Purserl do
             process_warnings(state, v["warnings"], v["errors"], :wip)
 
             v["errors"]
-            |> Enum.map(fn %{"moduleName" => mod} -> GenServer.cast(@name, {:got_error, mod}) end)
+            |> Enum.map(fn %{"moduleName" => mod} -> GenServer.cast(__MODULE__, {:got_error, mod}) end)
 
             {:noreply, state}
 
@@ -496,7 +494,7 @@ defmodule DevHelpers.Purserl do
 
     case module_name do
       nil -> nil
-      _ -> GenServer.cast(@name, {:erl_step_complete, module_name})
+      _ -> GenServer.cast(__MODULE__, {:erl_step_complete, module_name})
     end
   end
 

--- a/lib/purserl_compiler.ex
+++ b/lib/purserl_compiler.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.Compile.Purserl do
 
   use Mix.Task.Compiler
 
-  alias DevHelpers.Purserl, as: P
+  alias Purserl, as: P
 
   @recursive true
 


### PR DESCRIPTION
The previous version measured compilation time from the start to the finish of erlang compilation. This is not the correct way to measure purs compilation time. DevHelpers.Purserl have also been renamed to make it easier to work with